### PR TITLE
Change references to the department from DIT to DBT

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,6 @@
 # Security Policy
-The Department for International Trade (DIT) secure UK and global prosperity by promoting and financing international trade and investment, and championing free trade. Read more about what we do on [GOV.UK](https://www.gov.uk/government/organisations/department-for-international-trade/about)
+
+The Department for Business and Trade (DBT) supports businesses to invest, grow and export, creating jobs and opportunities across the country. Read more about what we do on [GOV.UK](https://www.gov.uk/government/organisations/department-for-business-and-trade/about).
 
 ## Reporting a Vulnerability
 
@@ -16,4 +17,4 @@ Vulnerability reporting guidelines
 - To submit your report, you will need to agree to the HackerOne Terms and Conditions and acknowledge that you have read their Privacy Policy and Disclosure Guidelines
 -	Once you have submitted the report, it will be assessed by NCC Group within five working days, and forwarded to the affected owners as soon as possible. 
 
-The DIT Cyber Team will attempt to make contact with the affected owner. However, the affected owner holds responsibility for resolving the issue.
+The DBT Cyber Team will attempt to make contact with the affected owner. However, the affected owner holds responsibility for resolving the issue.


### PR DESCRIPTION
This changes references to the Department for International Trade (DIT) to the Department for Business and Trade (DBT), which is the current name of the department. This includes changing the link to where people can read about the department, and changes the brief description of the department to how it is now described at
https://www.gov.uk/government/organisations/department-for-business-and-trade.