### PR TITLE
feature/remove-actions-not-needed-at-org-level

### DIFF
--- a/.github/workflows/language-agnostic.yml
+++ b/.github/workflows/language-agnostic.yml
@@ -21,20 +21,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Scan with Trufflehog
-        id: trufflehog
-        uses: trufflesecurity/trufflehog@6641d4ba5b684fffe195b9820345de1bf19f3181
-        continue-on-error: true
-        with:
-          path: ./
-          base: ${{ github.head_ref }}
-          extra_args: --only-verified
-
-      - name: Scan Results Status
-        if: steps.trufflehog.outcome == 'failure'
-        run: exit 1
+      # Disable for now, while trufflehog is going through IRAP
+      # - name: Run TruffleHog scan
+      #   run: |
+      #     docker run --rm -v ${{ github.workspace }}:/repo \
+      #       trufflesecurity/trufflehog:3.8.6 \
+      #       git file:///repo \
+      #       --since-commit main \
+      #       --branch ${{ github.head_ref }} \
+      #       --github-actions \
+      #       --fail

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,27 +29,3 @@ jobs:
       - name: Check if org-wide pre-commit hook ran before push
         run: |
           git log ${{ github.event.pull_request.head.sha }} --format=%B -1 | git interpret-trailers --parse | grep '${{ env.SIGNED_OFF_MESSAGE }}'
-
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Lint with Ruff
-        uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad
-        with:
-          version: "0.12.3"
-
-  bandit:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      actions: read
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Perform Bandit analysis
-        uses: PyCQA/bandit-action@8a1b30610f61f3f792fe7556e888c9d7dffa52de


### PR DESCRIPTION
Remove bandit and ruff, these should be decided to be used by individual teams
Disable trufflehog while it is going back through IRAP