### PR TITLE
feature/dont-fail-if-signed-off-header-missing

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,3 +29,4 @@ jobs:
       - name: Check if org-wide pre-commit hook ran before push
         run: |
           git log ${{ github.event.pull_request.head.sha }} --format=%B -1 | git interpret-trailers --parse | grep '${{ env.SIGNED_OFF_MESSAGE }}'
+        continue-on-error: true


### PR DESCRIPTION
To avoid blocking PRs while dev work is ongoing, if the signed off trailer is missing continue with the build