### PR TITLE
feature/add-default-pull-request-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!---
+THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
+--->
+
+## What
+
+<!---
+What is this PR doing, e.g. implementations, algorithms, etc.?
+ * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
+ * Explain like I'm 5 - try to make as few assumptions as possible about the reader
+ * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
+--->
+
+## Why
+
+<!---
+Why is this change happening, e.g. goals, use cases, stories, etc.?
+ * Explain what the problem was that this PR addresses.
+ * Explain why this solution was chosen, and any alternatives considered.
+ * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
+--->
+
+## How this has been tested
+
+- [ ] I have tested locally
+- [ ] Testing not required
+
+## Reviewer Checklist
+
+- [ ] I have reviewed the PR and ensured no secret values are present

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# .github
+# Repository templates
+
+Organization-wide repository templates are configured in this repo. (See our [pull request template](.github/pull_request_template.md) for an example).


### PR DESCRIPTION
Add a default PR template at the org level, that will be used by default for teams who currently have no template in their repository