### PR TITLE
feat: remove requirement for a steward to be named

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,30 @@
-<!---
-THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
---->
+# Description
 
-## What
+Please include a summary of the changes and the related issue including relevant motivation and context. Please also include a link to the corresponding JIRA ticket this merge request addresses.
 
-<!---
-What is this PR doing, e.g. implementations, algorithms, etc.?
- * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
- * Explain like I'm 5 - try to make as few assumptions as possible about the reader
- * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
---->
+## Contributors
 
-## Why
+Let's acknowledge the people who contributed to the work.
 
-<!---
-Why is this change happening, e.g. goals, use cases, stories, etc.?
- * Explain what the problem was that this PR addresses.
- * Explain why this solution was chosen, and any alternatives considered.
- * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
---->
+## Type of change
+
+- [ ] Refactoring (made code better without changing its behaviour)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ## How this has been tested
 
-- [ ] I have tested locally
-- [ ] Testing not required
+Please describe the tests that you ran to verify your changes.
+
+If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.
+
+## Checklist
+
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
 
 ## Reviewer Checklist
 

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -16,7 +16,6 @@ This checklist is designed to make it easier to improve the security posture of 
 - [ ] [Copy the SECURITY_CHECKLIST.md file](#copy-the-security_checklistmd-file)
 - [ ] [Review the GitHub CI/CD overview](#review-the-github-cicd-overview)
 - [ ] [Review the GitHub Safety Tips](#review-github-safety-tips)
-- [ ] [Add Steward to Repository access](#add-at-least-one-steward-to-repository-access)
 - [ ] [Create an admin team for the repository](#create-an-admin-team-for-the-repository)
 - [ ] [Review and limit maintainers with admin rights to the strict minimum](#review-and-limit-maintainers-with-admin-rights-to-the-strict-minimum)
 - [ ] [Review the Pull Request template](#review-pull-request-template)
@@ -102,16 +101,6 @@ In addition to adding at least one Steward, a new team with the admin role must 
 9. Enter the team name you used, and click the matching result in the autocomplete box
 10. On the next screen, choose the `Admin` role
 11. Click the `Add selection` button to complete the process
-
-## Add at least one steward to repository access
-
-To add a steward to a repository:
-
-1. Open the `Collaborators and teams` settings page. The url for this is `https://github.com/uktrade/REPO_NAME/settings/access`
-2. Use the `Add people` button to open the people finder autocomplete box.
-3. Find and click the user who is going to be a steward
-4. On the Choose a role page, select the `Steward` role.
-5. Repeat for any additional users who are going to be a steward
 
 ## Review and limit maintainers with admin rights to the strict minimum
 


### PR DESCRIPTION
# Description

Changes required to remove the requirement for a named 'steward' from the security checklist.

## Contributors

@SamW94 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Not required - updating a document.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

## Reviewer Checklist

- [X] I have reviewed the PR and ensured no secret values are present