### PR TITLE
bugfix/link-to-the-full-ci-cd-image-path

### DIFF
--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -79,7 +79,7 @@ To allow tracking of repositories that have successfully completed the reopening
 ## Review the GitHub CI/CD overview
 
 Internal contributors to the repository should review the CI/CD overview below
-![CI/CD overview](assets/CI-CD%20pipeline.svg)
+![CI/CD overview](https://raw.githubusercontent.com/uktrade/.github/refs/heads/main/assets/CI-CD%20pipeline.svg)
 
 ## Review GitHub Safety Tips
 


### PR DESCRIPTION
<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What
Use the full path link instead of a relative link
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
Other repositories use this link, they do not have the svg image locally it needs to point back to this repo
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [ ] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
